### PR TITLE
fix(cli): stop clear-text logging of API key in doctor command

### DIFF
--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -106,16 +106,23 @@ async function runDoctor(globals: GlobalOptions): Promise<void> {
       exitCode = 1;
     }
 
-    // API key (when cloud involved)
+    // API key (when cloud involved). Report presence only — never echo
+    // `apiKeySource`, which may hold a raw inline key rather than an
+    // `env:VAR_NAME` reference and would otherwise leak the credential to
+    // stdout/logs (and the --json output) in clear text (CWE-312/532).
     if (config.llm.mode !== 'local-only') {
-      const hasKey = resolveApiKey(config.llm.cloud.apiKeySource);
+      const apiKeySource = config.llm.cloud.apiKeySource;
+      const hasKey = resolveApiKey(apiKeySource);
+      const usesEnvRef = apiKeySource.startsWith('env:');
       checks.push({
         name: 'Cloud API key',
         ok: hasKey,
-        message: hasKey
-          ? config.llm.cloud.apiKeySource
-          : `Missing: ${config.llm.cloud.apiKeySource}`,
-        hint: hasKey ? undefined : 'Set the key in ~/.cortex/.env',
+        message: hasKey ? 'Configured' : 'Not configured',
+        hint: hasKey
+          ? usesEnvRef
+            ? undefined
+            : 'Reference the key via env:VAR_NAME instead of storing it inline in your config'
+          : 'Set the key referenced by llm.cloud.apiKeySource (see ~/.cortex/.env)',
       });
       if (!hasKey) exitCode = 1;
     }


### PR DESCRIPTION
The `cortex doctor` "Cloud API key" check echoed config.llm.cloud.apiKeySource verbatim to stdout and to the --json output. apiKeySource is meant to be an `env:VAR_NAME` reference, but the schema permits any string and users sometimes paste a raw key inline — in which case the credential was printed in clear text.

Report presence only (Configured / Not configured), like the status command already does, so no value derived from apiKeySource reaches a logging sink. Resolves CodeQL js/clear-text-logging alert #17 (CWE-312/319/532).