### PR TITLE
fix(security): redact secrets in CLI output and harden dashboard auth

### DIFF
--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -85,6 +85,45 @@ export function registerConfigCommand(program: Command): void {
 
 const DANGEROUS_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
 
+const REDACTED_APIKEY = '<redacted: inline key — reference it via env:VAR_NAME instead>';
+const REDACTED_TOKEN = '<redacted: server auth token>';
+
+/** An apiKeySource is a secret only when it holds a raw inline key, not an `env:VAR_NAME` reference. */
+function isInlineApiKey(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0 && !value.startsWith('env:');
+}
+
+/**
+ * If `key`/`value` names a secret config field, return its redacted placeholder;
+ * otherwise undefined. Covers the cloud API key (only when stored inline rather
+ * than as an `env:VAR_NAME` reference) and the server auth token, so
+ * `cortex config` never prints credentials in clear text (CWE-312/319/532).
+ */
+function redactSecretField(key: string, value: unknown): string | undefined {
+  if (key === 'apiKeySource' && isInlineApiKey(value)) return REDACTED_APIKEY;
+  if (key === 'token' && typeof value === 'string' && value.length > 0) return REDACTED_TOKEN;
+  return undefined;
+}
+
+/** Returns a deep copy of `value` with every secret field replaced by a placeholder. */
+function redactSecrets(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(redactSecrets);
+  if (value !== null && typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      out[k] = redactSecretField(k, v) ?? redactSecrets(v);
+    }
+    return out;
+  }
+  return value;
+}
+
+/** Redact a value echoed back for a specific dotted config key path (handles scalar and nested writes). */
+function redactValueForKey(key: string, value: unknown): unknown {
+  const leaf = key.slice(key.lastIndexOf('.') + 1);
+  return redactSecretField(leaf, value) ?? redactSecrets(value);
+}
+
 function getNestedValue(obj: Record<string, unknown>, path: string): unknown {
   const parts = path.split('.');
   let current: unknown = obj;
@@ -155,7 +194,7 @@ function readConfigFile(path: string): Record<string, unknown> {
 async function runConfigGet(key: string, globals: GlobalOptions): Promise<void> {
   try {
     const config = loadConfig({ configDir: globals.config ? resolve(globals.config) : undefined });
-    const value = getNestedValue(config as unknown as Record<string, unknown>, key);
+    const value = getNestedValue(redactSecrets(config) as Record<string, unknown>, key);
 
     if (value === undefined) {
       if (globals.json) {
@@ -202,10 +241,11 @@ async function runConfigSet(key: string, value: string, globals: GlobalOptions):
     mkdirSync(dirname(configPath), { recursive: true });
     writeFileSync(configPath, JSON.stringify(raw, null, 2) + '\n', 'utf-8');
 
+    const displayValue = redactValueForKey(key, parsed);
     if (globals.json) {
-      console.log(JSON.stringify({ key, value: parsed, saved: true }));
+      console.log(JSON.stringify({ key, value: displayValue, saved: true }));
     } else {
-      console.log(chalk.green(`✓ Set ${key} = ${JSON.stringify(parsed)}`));
+      console.log(chalk.green(`✓ Set ${key} = ${JSON.stringify(displayValue)}`));
     }
   } catch (err) {
     logger.error('Config set failed', { error: err instanceof Error ? err.message : String(err) });
@@ -217,9 +257,10 @@ async function runConfigList(globals: GlobalOptions): Promise<void> {
   try {
     const config = loadConfig({ configDir: globals.config ? resolve(globals.config) : undefined });
     const defaults = getDefaultConfig();
+    const safeConfig = redactSecrets(config) as Record<string, unknown>;
 
     if (globals.json) {
-      console.log(JSON.stringify(config));
+      console.log(JSON.stringify(safeConfig));
       return;
     }
 
@@ -228,7 +269,7 @@ async function runConfigList(globals: GlobalOptions): Promise<void> {
     console.log(chalk.dim('─'.repeat(50)));
 
     // Flatten and compare with defaults
-    const configFlat = flattenObject(config as unknown as Record<string, unknown>);
+    const configFlat = flattenObject(safeConfig);
     const defaultFlat = flattenObject(defaults as unknown as Record<string, unknown>);
 
     let hasNonDefault = false;

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -66,8 +66,12 @@ function ensureAuthToken(host: string, config: ReturnType<typeof loadConfig>): v
   config.server.auth.enabled = true;
   config.server.auth.token = token;
 
+  // Do not print the token itself — it is a credential and would land in
+  // terminal scrollback, shell history, and CI logs in clear text (CWE-312/532).
+  // It is persisted to the .env below; direct the user there instead.
   console.log(`\n  Auth token generated and saved to ${envPath}`);
-  console.log(`  Token: ${token}\n`);
+  console.log(`  It is required for API access — read it with:`);
+  console.log(`    grep CORTEX_SERVER_AUTH_TOKEN ${envPath}\n`);
 }
 
 async function runServe(

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -14,7 +14,7 @@ import { createQueryRoutes } from './routes/query.js';
 import { createContradictionRoutes } from './routes/contradictions.js';
 import { createStatusRoutes } from './routes/status.js';
 import { createEventRelay } from './ws/event-relay.js';
-import { createAuthMiddleware } from './middleware/auth.js';
+import { createAuthMiddleware, validateWsToken } from './middleware/auth.js';
 
 const logger = createLogger('server');
 
@@ -78,18 +78,16 @@ export async function startServer(options: ServerOptions): Promise<void> {
   // Trust reverse proxy (nginx) — required for correct IP detection and rate limiting
   app.set('trust proxy', 1);
 
-  // Middleware — CORS
+  // Middleware — CORS. Allow only the explicitly configured origins (e.g. the
+  // Vite dev server). The dashboard is served same-origin with the API, so it
+  // needs no CORS grant; reflecting arbitrary localhost:* origins would let any
+  // local page read the user's private knowledge graph cross-origin (CWE-346/942).
   const corsOrigin = config.server?.cors ?? [];
   app.use(cors({
     origin: (origin, callback) => {
-      // Allow requests with no origin (curl, server-to-server)
+      // Allow requests with no Origin header (curl, server-to-server, same-origin navigations)
       if (!origin) return callback(null, true);
-      // Check explicit whitelist first
       if (corsOrigin.includes(origin)) return callback(null, true);
-      // Allow any localhost/127.0.0.1 origin (any port)
-      if (/^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/.test(origin)) {
-        return callback(null, true);
-      }
       logger.warn('CORS rejected', { origin, allowed: corsOrigin });
       callback(new Error('CORS not allowed'));
     },
@@ -175,13 +173,17 @@ export async function startServer(options: ServerOptions): Promise<void> {
       return `${tokenMeta}\n${tokenScript}\n${html}`;
     };
 
-    // SPA fallback: serve index.html for all non-API routes
+    // SPA fallback: serve index.html for all non-API routes.
     const spaLimiter = rateLimit({ windowMs: 60_000, max: 60 });
-    app.get('*', spaLimiter, (_req, res) => {
+    app.get('*', spaLimiter, (req, res) => {
       const indexPath = resolve(webDist, 'index.html');
-      if (config.server.auth.enabled && config.server.auth.token) {
-        const html = injectAuthToken(readFileSync(indexPath, 'utf-8'));
-        res.type('html').send(html);
+      const authActive = config.server.auth.enabled && !!config.server.auth.token;
+      // Only embed the auth token for a requester that already proves possession
+      // of it (Authorization: Bearer, or ?token=... on the initial document load).
+      // Anonymous clients get the app shell WITHOUT the token, so the credential
+      // is never disclosed to unauthenticated callers (CWE-312/CWE-522).
+      if (authActive && validateWsToken(config, host, req.url, req.headers.authorization)) {
+        res.type('html').send(injectAuthToken(readFileSync(indexPath, 'utf-8')));
       } else {
         res.sendFile(indexPath);
       }

--- a/packages/web/src/stores/api.ts
+++ b/packages/web/src/stores/api.ts
@@ -1,13 +1,24 @@
 const API_BASE = '/api/v1';
 
+const TOKEN_STORAGE_KEY = 'cortex-auth-token';
+
 function getAuthToken(): string | undefined {
   if (typeof window === 'undefined') return undefined;
 
+  // The server only embeds the token for an authenticated document load
+  // (e.g. opening the dashboard with ?token=...). Persist it for this tab so a
+  // plain refresh keeps working, while anonymous loads still receive no token.
   const win = window as typeof window & { __CORTEX_TOKEN__?: string };
-  if (win.__CORTEX_TOKEN__) return win.__CORTEX_TOKEN__;
+  const injected =
+    win.__CORTEX_TOKEN__ ??
+    document.querySelector('meta[name="cortex-auth-token"]')?.getAttribute('content') ??
+    undefined;
+  if (injected) {
+    try { sessionStorage.setItem(TOKEN_STORAGE_KEY, injected); } catch { /* storage unavailable */ }
+    return injected;
+  }
 
-  const meta = document.querySelector('meta[name="cortex-auth-token"]');
-  return meta?.getAttribute('content') ?? undefined;
+  try { return sessionStorage.getItem(TOKEN_STORAGE_KEY) ?? undefined; } catch { return undefined; }
 }
 
 function authHeaders(extra?: Record<string, string>): Record<string, string> {

--- a/packages/web/src/stores/websocket.ts
+++ b/packages/web/src/stores/websocket.ts
@@ -28,14 +28,25 @@ interface WebSocketState {
 let ws: WebSocket | null = null;
 let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 
+const TOKEN_STORAGE_KEY = 'cortex-auth-token';
+
 function getAuthToken(): string | undefined {
   if (typeof window === 'undefined') return undefined;
 
+  // Mirror api.ts: prefer the server-injected token (authenticated load) and
+  // persist it per-tab so refreshes/reconnects keep working; fall back to the
+  // stored value. Anonymous loads receive no token from the server.
   const win = window as typeof window & { __CORTEX_TOKEN__?: string };
-  if (win.__CORTEX_TOKEN__) return win.__CORTEX_TOKEN__;
+  const injected =
+    win.__CORTEX_TOKEN__ ??
+    document.querySelector('meta[name="cortex-auth-token"]')?.getAttribute('content') ??
+    undefined;
+  if (injected) {
+    try { sessionStorage.setItem(TOKEN_STORAGE_KEY, injected); } catch { /* storage unavailable */ }
+    return injected;
+  }
 
-  const meta = document.querySelector('meta[name="cortex-auth-token"]');
-  return meta?.getAttribute('content') ?? undefined;
+  try { return sessionStorage.getItem(TOKEN_STORAGE_KEY) ?? undefined; } catch { return undefined; }
 }
 
 function buildWsUrl(): string {

--- a/tests/integration/cli.test.ts
+++ b/tests/integration/cli.test.ts
@@ -102,6 +102,41 @@ describe('CLI Integration', () => {
     });
   });
 
+  describe('cortex config secret redaction', () => {
+    beforeEach(() => {
+      runCLI('init --non-interactive', { cwd: tempDir });
+    });
+
+    it('never prints an inline API key (get/list/--json) but keeps env: references', () => {
+      const SECRET = 'sk-INLINE-APIKEY-DO-NOT-LEAK-0001';
+      const setOut = runCLI(`config set llm.cloud.apiKeySource ${SECRET}`, { cwd: tempDir });
+      expect(setOut).not.toContain(SECRET);
+
+      const get = runCLI('config get llm.cloud.apiKeySource', { cwd: tempDir });
+      expect(get).not.toContain(SECRET);
+      expect(get).toContain('<redacted');
+
+      expect(runCLI('config get llm.cloud', { cwd: tempDir })).not.toContain(SECRET);
+      expect(runCLI('config list', { cwd: tempDir })).not.toContain(SECRET);
+      expect(runCLI('config list --json', { cwd: tempDir })).not.toContain(SECRET);
+
+      // env:VAR_NAME references name an env var, not the secret — keep them visible.
+      runCLI('config set llm.cloud.apiKeySource env:CORTEX_TEST_KEY', { cwd: tempDir });
+      expect(runCLI('config get llm.cloud.apiKeySource', { cwd: tempDir }).trim()).toBe('env:CORTEX_TEST_KEY');
+    });
+
+    it('never prints the server auth token (get/list/--json/set echo)', () => {
+      const TOKEN = 'SERVER-AUTH-TOKEN-DO-NOT-LEAK-0002';
+      const setOut = runCLI(`config set server.auth.token ${TOKEN}`, { cwd: tempDir });
+      expect(setOut).not.toContain(TOKEN);
+
+      expect(runCLI('config get server.auth.token', { cwd: tempDir })).not.toContain(TOKEN);
+      expect(runCLI('config get server.auth', { cwd: tempDir })).not.toContain(TOKEN);
+      expect(runCLI('config list', { cwd: tempDir })).not.toContain(TOKEN);
+      expect(runCLI('config list --json', { cwd: tempDir })).not.toContain(TOKEN);
+    });
+  });
+
   describe('cortex status --json', () => {
     it('should return valid JSON', () => {
       runCLI('init --non-interactive --mode local-only', { cwd: tempDir });


### PR DESCRIPTION
Follow-up to the doctor.ts clear-text-logging fix; a cross-package audit surfaced more credential-exposure paths, each confirmed by adversarial review.

CLI:
- `config get/list/set` now redact the cloud API key (when stored inline) AND the server auth token; `env:VAR_NAME` references are preserved (not secrets).
- `serve` no longer prints the generated auth token to stdout — it points to ~/.cortex/.env instead.

Server:
- The SPA fallback route only embeds the auth token for a request that proves possession of it (Authorization: Bearer or ?token=). An anonymous `GET /` no longer receives the token, closing an auth bypass where any unauthenticated client could scrape the Bearer token from the dashboard HTML (CWE-312/522).
- CORS no longer reflects arbitrary localhost:* origins; only the configured `server.cors` origins are allowed (CWE-346/942).

Web:
- Dashboard persists the injected token to sessionStorage (per tab) so a plain refresh keeps working now that anonymous loads receive no token.

Tests:
- Regression tests asserting `config` never emits the inline API key or server auth token (get/list/--json/set echo) while keeping env: references.

Build + 121 tests green; verified with live server smoke tests (anonymous load gets no token, API auth enforced, foreign CORS origin rejected).